### PR TITLE
Truncate ID to 64 chars

### DIFF
--- a/lib/contentful/database_importer/resource_coercions.rb
+++ b/lib/contentful/database_importer/resource_coercions.rb
@@ -112,7 +112,7 @@ module Contentful
       end
 
       def asset_id_from_name(name)
-        Support.snake_case(name.gsub(/[^\w ]/i, '_'))
+        Support.snake_case(name.gsub(/[^\w ]/i, '_'))[0...64]
       end
     end
   end


### PR DESCRIPTION
Updated `asset_id_from_name` to truncate the returned id to 64 characters as Contentful's API doesn't allow more than 64 characters. See https://www.contentful.com/developers/docs/references/content-management-api/#/introduction/resource-ids